### PR TITLE
fix: quesstion과 question_history 테이블 연관관계 적용

### DIFF
--- a/src/main/java/DM_plz/family_farm_main_server/qna/domain/Question.java
+++ b/src/main/java/DM_plz/family_farm_main_server/qna/domain/Question.java
@@ -1,6 +1,7 @@
 package DM_plz.family_farm_main_server.qna.domain;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -9,6 +10,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -28,6 +30,9 @@ public class Question {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "question_id")
 	private Long id;
+
+	@OneToMany(mappedBy = "question")
+	private List<QuestionHistory> questionHistories;
 
 	@Column(name = "question_content")
 	private String questionContent;

--- a/src/main/java/DM_plz/family_farm_main_server/qna/domain/QuestionHistory.java
+++ b/src/main/java/DM_plz/family_farm_main_server/qna/domain/QuestionHistory.java
@@ -33,6 +33,10 @@ public class QuestionHistory {
 	@Column(name = "question_history_id")
 	private Long id;
 
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "question_id")
+	private Question question;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "family_id")
 	private Family family;


### PR DESCRIPTION
## PR 유형

어떤 종류의 변경 사항인가요? (해당 사항에 모두 체크)

- [x] 버그 수정 (기존 문제를 수정)
- [ ] 기능 추가 (새로운 기능)
- [ ] 코드 스타일 수정 (포맷팅, 세미콜론 수정 등, 논리적 변경 없음)
- [ ] 리팩토링 (기능 수정 없이 코드 리팩토링)
- [ ] 문서 수정 (문서 추가 또는 수정)
- [ ] 테스트 추가 (기존 코드에 대한 테스트 추가)
- [ ] 빌드 또는 CI 관련 변경 사항

## 해결하려는 문제가 무엇인가요?
* question테이블과 question_history 테이블 간의 연관관계 미 적용 문제

## 어떻게 해결했나요?
* JPA를 이용하여, question테이블과 question_history 테이블 간의 연관관계 추가
* 추가적으로, 비즈니스 요구사항을 고려하여, question_history에서 question 테이블을 eager fetch join 하게 설정함

## 이슈
resolves #23 