### PR TITLE
현재 진행중인 질문이 노출되는 기능(Q-1) API 구현

### DIFF
--- a/src/main/java/DM_plz/family_farm_main_server/family/dao/FamilyRepository.java
+++ b/src/main/java/DM_plz/family_farm_main_server/family/dao/FamilyRepository.java
@@ -8,6 +8,8 @@ import DM_plz.family_farm_main_server.family.domain.Family;
 
 public interface FamilyRepository extends JpaRepository<Family, Long> {
 
+	Optional<Family> findById(Long id);
+
 	Optional<Family> findByInviteCode(String inviteCode);
 
 }

--- a/src/main/java/DM_plz/family_farm_main_server/family/domain/Family.java
+++ b/src/main/java/DM_plz/family_farm_main_server/family/domain/Family.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import DM_plz.family_farm_main_server.member.domain.MemberDetail;
 import DM_plz.family_farm_main_server.qna.domain.QuestionHistory;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -39,7 +40,7 @@ public class Family {
 	@Column(name = "invite_code")
 	private String inviteCode;
 
-	@OneToMany(mappedBy = "family")
+	@OneToMany(mappedBy = "family", cascade = CascadeType.ALL)
 	private List<QuestionHistory> questionHistories;
 
 	@CreationTimestamp

--- a/src/main/java/DM_plz/family_farm_main_server/member/application/MemberService.java
+++ b/src/main/java/DM_plz/family_farm_main_server/member/application/MemberService.java
@@ -28,7 +28,7 @@ public class MemberService {
 	@Transactional
 	public Member signUp(SignUpDTO signUpDTO) {
 
-		Member newMember = signUpMapper.toAccount(signUpDTO);
+		Member newMember = signUpMapper.toMember(signUpDTO);
 		MemberDetail newMemberDetail = signUpMapper.toMemberDetail(signUpDTO);
 
 		newMemberDetail.relationAccount(newMember);

--- a/src/main/java/DM_plz/family_farm_main_server/member/dto/SignUpMapper.java
+++ b/src/main/java/DM_plz/family_farm_main_server/member/dto/SignUpMapper.java
@@ -10,7 +10,7 @@ import DM_plz.family_farm_main_server.member.domain.MemberDetail;
 public interface SignUpMapper {
 
 	@Mapping(source = "OAuthProvider", target = "authProvider")
-	Member toAccount(SignUpDTO signUpDTO);
+	Member toMember(SignUpDTO signUpDTO);
 
 	MemberDetail toMemberDetail(SignUpDTO signUpDTO);
 

--- a/src/main/java/DM_plz/family_farm_main_server/qna/api/QnaController.java
+++ b/src/main/java/DM_plz/family_farm_main_server/qna/api/QnaController.java
@@ -1,0 +1,27 @@
+package DM_plz.family_farm_main_server.qna.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import DM_plz.family_farm_main_server.qna.application.QuestionService;
+import DM_plz.family_farm_main_server.qna.dto.CurrentQuestion;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/question")
+public class QnaController {
+
+	private final QuestionService questionService;
+
+	@GetMapping("/")
+	public ResponseEntity<CurrentQuestion> getCurrentQuestion(@RequestParam Long familyId) {
+
+		CurrentQuestion currentQuestion = questionService.getCurrentQuestion(familyId);
+
+		return ResponseEntity.ok(currentQuestion);
+	}
+}

--- a/src/main/java/DM_plz/family_farm_main_server/qna/application/QuestionService.java
+++ b/src/main/java/DM_plz/family_farm_main_server/qna/application/QuestionService.java
@@ -1,0 +1,71 @@
+package DM_plz.family_farm_main_server.qna.application;
+
+import java.time.LocalTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import DM_plz.family_farm_main_server.common.exception.errorCode.CommonErrorCode;
+import DM_plz.family_farm_main_server.common.exception.exception.CommonException;
+import DM_plz.family_farm_main_server.qna.dao.QuestionHistoryRepository;
+import DM_plz.family_farm_main_server.qna.dao.QuestionRepository;
+import DM_plz.family_farm_main_server.qna.domain.Question;
+import DM_plz.family_farm_main_server.qna.domain.QuestionHistory;
+import DM_plz.family_farm_main_server.qna.dto.CurrentQuestion;
+import DM_plz.family_farm_main_server.qna.dto.CurrentQuestionMapper;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class QuestionService {
+
+	private final QuestionHistoryRepository questionHistoryRepository;
+
+	private final QuestionRepository questionRepository;
+
+	private final CurrentQuestionMapper currentQuestionMapper;
+
+	private final static LocalTime localTime = LocalTime.of(10, 00, 00);
+
+	public CurrentQuestion getCurrentQuestion(Long familyId) {
+
+		QuestionHistory findQuestionHistory = questionHistoryRepository.findTopByFamilyIdOrderByIdDesc(familyId)
+			.orElseThrow(
+				() -> new CommonException(CommonErrorCode.NULL_POINTER_EXCEPTION, null)
+			);
+
+		Question findQuestion = findQuestionHistory.getQuestion();
+
+		// 새로운 질문이 생성하여 반환해야 하는 경우
+		if (findQuestionHistory.getIsComplete() && LocalTime.now().isAfter(localTime)) {
+			QuestionHistory nextQuestionHistory = getNextQuestion(findQuestionHistory);
+
+			return currentQuestionMapper.toCurrentQuestion(nextQuestionHistory, nextQuestionHistory.getQuestion());
+
+			// 기존의 질문을 반환해야 하는 경우
+		} else {
+
+			return currentQuestionMapper.toCurrentQuestion(findQuestionHistory, findQuestion);
+		}
+	}
+
+	@Transactional
+	public QuestionHistory getNextQuestion(QuestionHistory questionHistory) {
+
+		Question findQuestion = questionRepository.findById(questionHistory.getQuestion().getId() + 1)
+			.orElseThrow(
+				() -> new CommonException(CommonErrorCode.NULL_POINTER_EXCEPTION, null)
+			);
+
+		QuestionHistory newQuestionHistory = QuestionHistory.builder()
+			.question(findQuestion)
+			.family(questionHistory.getFamily())
+			.isComplete(false)
+			.build();
+
+		questionHistoryRepository.save(newQuestionHistory);
+
+		return newQuestionHistory;
+	}
+}

--- a/src/main/java/DM_plz/family_farm_main_server/qna/dao/QuestionHistoryRepository.java
+++ b/src/main/java/DM_plz/family_farm_main_server/qna/dao/QuestionHistoryRepository.java
@@ -1,0 +1,12 @@
+package DM_plz.family_farm_main_server.qna.dao;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import DM_plz.family_farm_main_server.qna.domain.QuestionHistory;
+
+public interface QuestionHistoryRepository extends JpaRepository<QuestionHistory, Long> {
+
+	Optional<QuestionHistory> findTopByFamilyIdOrderByIdDesc(Long familyId);
+}

--- a/src/main/java/DM_plz/family_farm_main_server/qna/dao/QuestionRepository.java
+++ b/src/main/java/DM_plz/family_farm_main_server/qna/dao/QuestionRepository.java
@@ -1,0 +1,12 @@
+package DM_plz.family_farm_main_server.qna.dao;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import DM_plz.family_farm_main_server.qna.domain.Question;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+	Optional<Question> findById(Long id);
+}

--- a/src/main/java/DM_plz/family_farm_main_server/qna/dto/CurrentQuestion.java
+++ b/src/main/java/DM_plz/family_farm_main_server/qna/dto/CurrentQuestion.java
@@ -1,0 +1,15 @@
+package DM_plz.family_farm_main_server.qna.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CurrentQuestion {
+
+	private Long questionHistoryId;
+
+	private String question;
+
+	private Boolean isAnswered;
+}

--- a/src/main/java/DM_plz/family_farm_main_server/qna/dto/CurrentQuestionMapper.java
+++ b/src/main/java/DM_plz/family_farm_main_server/qna/dto/CurrentQuestionMapper.java
@@ -1,0 +1,16 @@
+package DM_plz.family_farm_main_server.qna.dto;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import DM_plz.family_farm_main_server.qna.domain.Question;
+import DM_plz.family_farm_main_server.qna.domain.QuestionHistory;
+
+@Mapper(componentModel = "spring")
+public interface CurrentQuestionMapper {
+
+	@Mapping(source = "questionHistory.isComplete", target = "isAnswered")
+	@Mapping(source = "question.questionContent", target = "question")
+	CurrentQuestion toCurrentQuestion(QuestionHistory questionHistory, Question question);
+
+}

--- a/src/test/java/DM_plz/family_farm_main_server/qna/application/QuestionServiceTest.java
+++ b/src/test/java/DM_plz/family_farm_main_server/qna/application/QuestionServiceTest.java
@@ -1,0 +1,154 @@
+package DM_plz.family_farm_main_server.qna.application;
+
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import DM_plz.family_farm_main_server.family.dao.FamilyRepository;
+import DM_plz.family_farm_main_server.family.domain.Family;
+import DM_plz.family_farm_main_server.qna.dao.QuestionHistoryRepository;
+import DM_plz.family_farm_main_server.qna.dao.QuestionRepository;
+import DM_plz.family_farm_main_server.qna.domain.Question;
+import DM_plz.family_farm_main_server.qna.domain.QuestionHistory;
+import DM_plz.family_farm_main_server.qna.dto.CurrentQuestion;
+
+@SpringBootTest
+class QuestionServiceTest {
+
+	@Autowired
+	QuestionService questionService;
+
+	@Autowired
+	FamilyRepository familyRepository;
+
+	@Autowired
+	QuestionRepository questionRepository;
+
+	@Autowired
+	QuestionHistoryRepository questionHistoryRepository;
+
+	@Test
+	@DisplayName("질문이 완료되면, 설정한 시간에 새로운 질문이 나오는가")
+	void newQuestionAtTime() {
+
+		// Given
+		Family newFamily = Family.builder()
+			.build();
+		Question firstQuestion = Question.builder()
+			.questionContent("당신이 가장 좋아하는 것은?")
+			.build();
+		Question secondQuestion = Question.builder()
+			.questionContent("사랑한다고 말해보세요!")
+			.build();
+
+		QuestionHistory newQuestionHistory = QuestionHistory.builder()
+			.isComplete(true)
+			.question(firstQuestion)
+			.family(newFamily)
+			.build();
+
+		familyRepository.save(newFamily);
+		questionRepository.save(firstQuestion);
+		questionRepository.save(secondQuestion);
+		questionHistoryRepository.save(newQuestionHistory);
+
+		// When
+		CurrentQuestion currentQuestion = questionService.getCurrentQuestion(newFamily.getId());
+
+		// Then
+		if (LocalTime.now().isAfter(LocalTime.of(10, 00, 00))) {
+			Assertions.assertEquals("사랑한다고 말해보세요!", currentQuestion.getQuestion());
+		} else {
+			Assertions.assertEquals("당신이 가장 좋아하는 것은?", currentQuestion.getQuestion());
+		}
+
+	}
+
+	@Test
+	@DisplayName("질문이 완료되지 않으면, 새로운 질문이 나오지 않는가")
+	void noNewQuestionIfNotCompleted() {
+
+		// Given
+		Family newFamily = Family.builder()
+			.build();
+		Question firstQuestion = Question.builder()
+			.questionContent("당신이 가장 좋아하는 것은?")
+			.build();
+		Question secondQuestion = Question.builder()
+			.questionContent("사랑한다고 말해보세요!")
+			.build();
+
+		QuestionHistory newQuestionHistory = QuestionHistory.builder()
+			.isComplete(false)
+			.question(firstQuestion)
+			.family(newFamily)
+			.build();
+
+		familyRepository.save(newFamily);
+		questionRepository.save(firstQuestion);
+		questionRepository.save(secondQuestion);
+		questionHistoryRepository.save(newQuestionHistory);
+
+		// When
+		CurrentQuestion currentQuestion = questionService.getCurrentQuestion(newFamily.getId());
+
+		// Then
+		Assertions.assertEquals("당신이 가장 좋아하는 것은?", currentQuestion.getQuestion());
+	}
+
+	@Test
+	@DisplayName("같은 가족들끼리만 같은 질문을 공유해야 한다.")
+	void shareSameQuestionWithSameFamily() {
+
+		// Given
+		Family firstFamily = Family.builder()
+			.build();
+		Family secondFamily = Family.builder()
+			.build();
+
+		Question firstQuestion = Question.builder()
+			.questionContent("당신이 가장 좋아하는 것은?")
+			.build();
+		Question secondQuestion = Question.builder()
+			.questionContent("사랑한다고 말해보세요!")
+			.build();
+		Question thirdQuestion = Question.builder()
+			.questionContent("지금 먹고 싶은 것은?")
+			.build();
+		Question fourthQuestion = Question.builder()
+			.questionContent("지금 듣고 있는 음악은?")
+			.build();
+
+		QuestionHistory newQuestionHistoryA = QuestionHistory.builder()
+			.isComplete(false)
+			.question(firstQuestion)
+			.family(firstFamily)
+			.build();
+		QuestionHistory newQuestionHistoryB = QuestionHistory.builder()
+			.isComplete(false)
+			.question(thirdQuestion)
+			.family(secondFamily)
+			.build();
+
+		familyRepository.save(firstFamily);
+		familyRepository.save(secondFamily);
+		questionRepository.save(firstQuestion);
+		questionRepository.save(secondQuestion);
+		questionRepository.save(thirdQuestion);
+		questionRepository.save(fourthQuestion);
+		questionHistoryRepository.save(newQuestionHistoryA);
+		questionHistoryRepository.save(newQuestionHistoryB);
+
+		// When
+		CurrentQuestion currentQuestionWithFirstFamily = questionService.getCurrentQuestion(firstFamily.getId());
+		CurrentQuestion currentQuestionWithSecondFamily = questionService.getCurrentQuestion(secondFamily.getId());
+
+		// Then
+		Assertions.assertEquals("당신이 가장 좋아하는 것은?", currentQuestionWithFirstFamily.getQuestion());
+		Assertions.assertEquals("지금 먹고 싶은 것은?", currentQuestionWithSecondFamily.getQuestion());
+	}
+}


### PR DESCRIPTION
## PR 유형

어떤 종류의 변경 사항인가요? (해당 사항에 모두 체크)

- [ ] 버그 수정 (기존 문제를 수정)
- [x] 기능 추가 (새로운 기능)
- [ ] 코드 스타일 수정 (포맷팅, 세미콜론 수정 등, 논리적 변경 없음)
- [x] 리팩토링 (기능 수정 없이 코드 리팩토링)
- [ ] 문서 수정 (문서 추가 또는 수정)
- [ ] 테스트 추가 (기존 코드에 대한 테스트 추가)
- [ ] 빌드 또는 CI 관련 변경 사항

## 해결하려는 문제가 무엇인가요?
* family 테이블과 question_history 테이블은 CASCADE 관계에 있어야 한다.
* 지금 진행 중인 질문이 노출된다.
  * 질문이 완료되고, 설정한 시간(오전 10시)이 지나야지만, 새로운 질문이 노출된다.
  * 같은 가족들끼리는 같은 질문을 공유한다.

## 어떻게 해결했나요?
* Family 엔티티에 QuestionHistory 엔티티를 CASCADE 하는 옵션 추가
* QuestionService를 구현하여 기능을 구현

## 이슈

resolves #17 
resolves #20 
